### PR TITLE
fix: bump Go toolchain to 1.26 to unblock Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Download dependencies
         run: go mod download
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Golang image as the base image
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Set the working directory
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fulgerX2007/clickhouse-schemaflow-visualizer
 
-go 1.23.8
+go 1.26.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0


### PR DESCRIPTION
## Summary

- `golang:1.23-alpine` builder failed `go mod download` because a transitive dep (likely `bytedance/sonic` via `gin-gonic/gin@v1.10.0`) declares `go >= 1.24.0`, and Alpine's default `GOTOOLCHAIN=local` blocks auto-upgrade.
- Bumped the three Go pins to 1.26: `Dockerfile`, `go.mod` directive, and both `setup-go` steps in `.github/workflows/release.yml`.
- No source changes — code is forward-compatible from 1.23.

## Failing CI output (before)

```
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

## Test plan

- [x] `docker build -t ch-schema-flow:verify-1.26 .` succeeds locally on `golang:1.26-alpine` (`go mod download` 10.6s, `go build` 26.1s)
- [ ] On merge + `v*` tag, `Docker Build and Publish` reaches the push step
- [ ] On merge + `v*` tag, `Release` workflow (test + goreleaser jobs) passes with Go 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)