### PR TITLE
fix: bump Go toolchain to 1.26 to unblock Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Download dependencies
         run: go mod download
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Golang image as the base image
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Set the working directory
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fulgerX2007/clickhouse-schemaflow-visualizer
 
-go 1.24.0
+go 1.26.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0


### PR DESCRIPTION
## Summary

Master had `go.mod` at `go 1.24.0` but `Dockerfile` still pinned `golang:1.23-alpine`, so `RUN go mod download` aborted in CI with:

```
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

Bumped all three Go pins to 1.26 in one go (vs just 1.24) for headroom against future dep upgrades like `bytedance/sonic v1.13.2`.

## Changes

- `Dockerfile` — `golang:1.23-alpine` → `golang:1.26-alpine`
- `go.mod` — `go 1.24.0` → `go 1.26.3`
- `.github/workflows/release.yml` — `setup-go` pinned to `1.26` in both test and goreleaser jobs

Supersedes #17 (had unresolvable conflicts from the squash-merge of #16).

## Test plan

- [x] `docker build .` succeeds locally on `golang:1.26-alpine` (`go mod download` and `go build` both pass)
- [ ] On tag push, `Docker Build and Publish` reaches the push step
- [ ] On tag push, `Release` workflow (test + goreleaser jobs) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)